### PR TITLE
Allow to add regex patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ms.strictObj({
 
 ## Strings
 
-Using the ms.string() method
+Using the `ms.string()` method:
 ```js
 ms.string()
 output = {type: 'string'})
@@ -42,13 +42,16 @@ output = {type: 'string'})
 ```js
 ms.string({pattern: '[a-z]+'})
 
+// Passing a javascript RegExp is equivalent to the above
+ms.string({pattern: /[a-z]+/})
+
 output = {
   type: 'string',
   pattern: '[a-z]+'
 }
 ```
 
-Setting the required flag (only possible within an object)
+Setting the required flag (only possible within an object):
 ```js
 ms.obj({
   foo: ms.required.string()
@@ -65,7 +68,7 @@ output = {
 }
 ```
 
-Simplified usage within objects
+Simplified usage within objects:
 ```js
 ms.obj({
   foo: 'string'
@@ -99,14 +102,14 @@ output = {
 
 ## Numbers and Integers
 
-Simplified usage within objects
+Simplified usage within objects:
 ```js
 ms.obj({
   foo: 'string'
 })
 ```
 
-Using the ms.number() method
+Using the `ms.number()` method:
 ```js
 ms.number()
 output = {type: 'number'}
@@ -122,7 +125,7 @@ output = {
 }
 ```
 
-Using the ms.integer() method
+Using the `ms.integer()` method:
 ```js
 ms.integer()
 output = {type: 'integer'}
@@ -138,7 +141,7 @@ ms.boolean()
 output = {type: 'boolean'})
 ```
 
-Simplified usage within objects
+Simplified usage within objects:
 ```js
 ms.obj({
   foo: 'boolean:required'
@@ -162,21 +165,20 @@ ms.obj()
 output = {type: 'object'}
 ```
 
-Don't allow additional properties with `strictObj()`
+Don't allow additional properties with `strictObj()`:
 ```js
 ms.strictObj({
   count: ms.integer()
 })
 
 output = {
-  type: 'object'
-  additionalProperties: false
+  type: 'object',
+  additionalProperties: false,
   properties: {
     count: {type: 'integer'}
   }
 }
 ```
-
 
 ## Arrays
 
@@ -194,7 +196,7 @@ output = {
 
 ```js
 // All values in an enumeration must be of the same type.
-ms.required.enum('foo', 'bar')
+ms.enum('foo', 'bar')
 
 output = {
   type: 'string',

--- a/README.md
+++ b/README.md
@@ -1,32 +1,203 @@
-# microschema
-
-<p align="center">
+<p align="right">
   <a href="https://travis-ci.org/upfrontIO/microschema">
     <img alt="Travis" src="https://img.shields.io/travis/upfrontIO/microschema/master.svg">
-  </a>
-  <a href="https://semantic-release.gitbooks.io/semantic-release/content/#highlights">
-    <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
   </a>
   <a href="https://www.npmjs.com/package/microschema">
     <img alt="npm latest version" src="https://img.shields.io/npm/v/microschema/latest.svg">
   </a>
+  <a href="https://semantic-release.gitbooks.io/semantic-release/content/#highlights">
+    <img alt="semantic-release" src="https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg">
+  </a>
 </p>
 
+# microschema
 
-Helper library to create JSON Schemas in a concise way.
+Small library without dependencies to create JSON Schemas in a concise way.
 
 Example:
 ```js
-const microschema = require('microschema')
+const ms = require('microschema')
 
-microschema.strictObj({
-  identity_id: 'string:required',
-  client_id: 'number',
-  redirect_uri: 'string:uri',
+ms.strictObj({
+  identityId: 'string:required',
+  clientId: 'number',
+  redirectUri: 'string:uri',
   scope: 'string',
-  ip_address: 'string',
-  children: microschema.arrayOf(microschema.strictObj({
+  ipAddress: ms.string({pattern: ''}),
+  children: ms.arrayOf(ms.strictObj({
     scope: 'string'
   }))
 })
+```
+
+
+## Strings
+
+Using the ms.string() method
+```js
+ms.string()
+output = {type: 'string'})
+```
+
+```js
+ms.string({pattern: '[a-z]+'})
+
+output = {
+  type: 'string',
+  pattern: '[a-z]+'
+}
+```
+
+Setting the required flag (only possible within an object)
+```js
+ms.obj({
+  foo: ms.required.string()
+})
+
+output = {
+  type: 'object',
+  required: ['foo'],
+  properties: {
+    foo: {
+      type: 'string'
+    }
+  }
+}
+```
+
+Simplified usage within objects
+```js
+ms.obj({
+  foo: 'string'
+})
+
+output = {
+  type: 'object',
+  properties: {
+    foo: {
+      type: 'string'
+    }
+  }
+}
+```
+
+```js
+ms.obj({
+  foo: 'string:required'
+})
+
+output = {
+  type: 'object',
+  required: ['foo'],
+  properties: {
+    foo: {
+      type: 'string'
+    }
+  }
+}
+```
+
+## Numbers and Integers
+
+Simplified usage within objects
+```js
+ms.obj({
+  foo: 'string'
+})
+```
+
+Using the ms.number() method
+```js
+ms.number()
+output = {type: 'number'}
+```
+
+```js
+ms.number({min: 0, max: 10})
+
+output = {
+  type: 'number',
+  minimum: 0,
+  maximum: 10
+}
+```
+
+Using the ms.integer() method
+```js
+ms.integer()
+output = {type: 'integer'}
+```
+
+The `integer()` methods also accepts `min` and `max` params the same as `number()` does.
+
+
+## Booleans
+
+```js
+ms.boolean()
+output = {type: 'boolean'})
+```
+
+Simplified usage within objects
+```js
+ms.obj({
+  foo: 'boolean:required'
+})
+
+output = {
+  type: 'object',
+  required: ['foo'],
+  properties: {
+    foo: {
+      type: 'boolean'
+    }
+  }
+}
+```
+
+## Objects
+
+```js
+ms.obj()
+output = {type: 'object'}
+```
+
+Don't allow additional properties with `strictObj()`
+```js
+ms.strictObj({
+  count: ms.integer()
+})
+
+output = {
+  type: 'object'
+  additionalProperties: false
+  properties: {
+    count: {type: 'integer'}
+  }
+}
+```
+
+
+## Arrays
+
+```js
+ms.arrayOf(ms.string())
+
+output = {
+  type: 'array',
+  items: {type: 'string'}
+}
+```
+
+
+## Enumerations
+
+```js
+// All values in an enumeration must be of the same type.
+ms.required.enum('foo', 'bar')
+
+output = {
+  type: 'string',
+  enum: ['foo', 'bar']
+}
 ```

--- a/index.js
+++ b/index.js
@@ -107,8 +107,7 @@ module.exports = {
     if (pattern) {
       if (pattern instanceof RegExp) {
         if (pattern.flags) {
-          throw new Error('JSON schema does not support regexp flags: ' +
-            `${pattern}`)
+          throw new Error(`JSON schema does not support regexp flags: ${pattern}`)
         }
         s.pattern = pattern.source
       } else {

--- a/index.js
+++ b/index.js
@@ -102,6 +102,22 @@ module.exports = {
     })
   },
 
+  string ({pattern} = {}) {
+    const s = {type: 'string'}
+    if (pattern) {
+      if (pattern instanceof RegExp) {
+        if (pattern.flags) {
+          throw new Error('JSON schema does not support regexp flags: ' +
+            `${pattern}`)
+        }
+        s.pattern = pattern.source
+      } else {
+        s.pattern = pattern
+      }
+    }
+    return this.decorate(s)
+  },
+
   number ({min, max, integer} = {}) {
     const type = integer ? 'integer' : 'number'
     const s = {type: type}

--- a/index.js
+++ b/index.js
@@ -131,6 +131,10 @@ module.exports = {
     return this.number(opts)
   },
 
+  boolean () {
+    return this.decorate({type: 'boolean'})
+  },
+
   decorate (obj) {
     if (this[isRequired]) obj[isRequired] = true
     return obj

--- a/test.js
+++ b/test.js
@@ -1,9 +1,9 @@
-const microschema = require('./index')
+const ms = require('./index')
 const test = require('ava').test
 const assert = require('assert')
 
 test('strictObj() creates an object with a single property', function (t) {
-  const schema = microschema.strictObj({foo: 'string'})
+  const schema = ms.strictObj({foo: 'string'})
 
   assert.deepEqual(schema, {
     type: 'object',
@@ -15,7 +15,7 @@ test('strictObj() creates an object with a single property', function (t) {
 })
 
 test('strictObj() creates an object with a uri string', function (t) {
-  const schema = microschema.strictObj({foo: 'string:uri'})
+  const schema = ms.strictObj({foo: 'string:uri'})
 
   assert.deepEqual(schema, {
     type: 'object',
@@ -27,7 +27,7 @@ test('strictObj() creates an object with a uri string', function (t) {
 })
 
 test('strictObj() creates an object with a required property', function (t) {
-  const schema = microschema.strictObj({
+  const schema = ms.strictObj({
     foo: 'string:required',
     bar: 'string'
   })
@@ -45,7 +45,7 @@ test('strictObj() creates an object with a required property', function (t) {
 
 
 test('enum() creates an enum of strings', function (t) {
-  const schema = microschema.enum('foo', 'bar')
+  const schema = ms.enum('foo', 'bar')
   assert.deepEqual(schema, {
     type: 'string',
     enum: ['foo', 'bar']
@@ -53,7 +53,7 @@ test('enum() creates an enum of strings', function (t) {
 })
 
 test('enum() creates an enum from an array', function (t) {
-  const schema = microschema.enum(['foo', 'bar'])
+  const schema = ms.enum(['foo', 'bar'])
   assert.deepEqual(schema, {
     type: 'string',
     enum: ['foo', 'bar']
@@ -62,7 +62,7 @@ test('enum() creates an enum from an array', function (t) {
 
 
 test('arrayOf() creates an array with a type of its items', function (t) {
-  const schema = microschema.arrayOf('integer')
+  const schema = ms.arrayOf('integer')
   assert.deepEqual(schema, {
     type: 'array',
     items: {type: 'integer'}
@@ -70,12 +70,12 @@ test('arrayOf() creates an array with a type of its items', function (t) {
 })
 
 test('number() creates a type number', function (t) {
-  const schema = microschema.number()
+  const schema = ms.number()
   assert.deepEqual(schema, {type: 'number'})
 })
 
 test('number() creates a type number with min and max', function (t) {
-  const schema = microschema.number({min: 0, max: 10})
+  const schema = ms.number({min: 0, max: 10})
   assert.deepEqual(schema, {
     type: 'number',
     minimum: 0,
@@ -84,12 +84,12 @@ test('number() creates a type number with min and max', function (t) {
 })
 
 test('integer() creates a type number', function (t) {
-  const schema = microschema.integer()
+  const schema = ms.integer()
   assert.deepEqual(schema, {type: 'integer'})
 })
 
 test('integer() creates a type integer with min and max', function (t) {
-  const schema = microschema.integer({min: 0, max: 10})
+  const schema = ms.integer({min: 0, max: 10})
   assert.deepEqual(schema, {
     type: 'integer',
     minimum: 0,
@@ -98,13 +98,13 @@ test('integer() creates a type integer with min and max', function (t) {
 })
 
 test('chaining creates a chain object', function (t) {
-  const chain = microschema.required
+  const chain = ms.required
   assert.ok(chain.strictObj instanceof Function)
 })
 
 test('chaining creates a required obj', function (t) {
-  const schema = microschema.obj({
-    myProperty: microschema.required.obj({foo: 'string'})
+  const schema = ms.obj({
+    myProperty: ms.required.obj({foo: 'string'})
   })
 
   assert.deepEqual(schema, {
@@ -122,8 +122,8 @@ test('chaining creates a required obj', function (t) {
 })
 
 test('chaining creates a required strict obj', function (t) {
-  const schema = microschema.obj({
-    myProperty: microschema.required.strictObj({foo: 'string'})
+  const schema = ms.obj({
+    myProperty: ms.required.strictObj({foo: 'string'})
   })
 
   assert.deepEqual(schema, {
@@ -142,8 +142,8 @@ test('chaining creates a required strict obj', function (t) {
 })
 
 test('chaining creates a required enum', function (t) {
-  const schema = microschema.obj({
-    myProperty: microschema.required.enum('foo', 'bar')
+  const schema = ms.obj({
+    myProperty: ms.required.enum('foo', 'bar')
   })
 
   assert.deepEqual(schema, {

--- a/test.js
+++ b/test.js
@@ -69,6 +69,61 @@ test('arrayOf() creates an array with a type of its items', function (t) {
   })
 })
 
+test('string() creates a type string', function (t) {
+  const schema = ms.string()
+  assert.deepEqual(schema, {type: 'string'})
+})
+
+test('required.string() creates a required string', function (t) {
+  const schema = ms.obj({
+    foo: ms.required.string()
+  })
+  assert.deepEqual(schema, {
+    type: 'object',
+    required: ['foo'],
+    properties: {
+      foo: {
+        type: 'string'
+      }
+    }
+  })
+})
+
+test('string({pattern}) adds a regex pattern', function (t) {
+  const schema = ms.string({
+    pattern: '[a-z]+'
+  })
+
+  assert.deepEqual(schema, {
+    type: 'string',
+    pattern: '[a-z]+'
+  })
+})
+
+test('string({pattern}) accepts a javascript regex', function (t) {
+  const schema = ms.string({
+    pattern: /[a-z]+/
+  })
+
+  assert.deepEqual(schema, {
+    type: 'string',
+    pattern: '[a-z]+'
+  })
+})
+
+test('string({pattern}) does not accept a javascript regex with flags', function (t) {
+  const method = () => {
+    ms.string({pattern: /[a-z]+/i})
+  }
+
+  assert.throws(method, (err) => {
+    assert.equal(err.message,
+      'JSON schema does not support regexp flags: /[a-z]+/i')
+
+    return true
+  })
+})
+
 test('number() creates a type number', function (t) {
   const schema = ms.number()
   assert.deepEqual(schema, {type: 'number'})

--- a/test.js
+++ b/test.js
@@ -152,6 +152,11 @@ test('integer() creates a type integer with min and max', function (t) {
   })
 })
 
+test('boolean() creates a type boolean', function (t) {
+  const schema = ms.boolean()
+  assert.deepEqual(schema, {type: 'boolean'})
+})
+
 test('chaining creates a chain object', function (t) {
   const chain = ms.required
   assert.ok(chain.strictObj instanceof Function)


### PR DESCRIPTION
## Changelog

Added `ms.string()` method.

Example:
```js
ms.string({pattern: /[a-z]+/})

output = {
  type: 'string',
  pattern: '[a-z]+'
}
```