### PR TITLE
fix: markdown headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ output = {
 }
 ```
 
-## Numbers and Integers
+## Numbers and Integers
 
 Simplified usage within objects:
 ```js


### PR DESCRIPTION
This change looks marginal, but it replaces the existing space with a space that makes the markdown headline work. ;)